### PR TITLE
Ubuntu-based image for zabbix-server-mysql with MSSQL tools

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,20 @@
+FROM zabbix/zabbix-server-mysql:7.0.26-ubuntu
+
+LABEL maintainer="mr.lioncub" \
+      link1="https://github.com/zabbix/zabbix-docker/tree/7.0" \
+      link2="https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server"
+
+USER root
+
+RUN set -x \
+  && wget -q https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb \
+  && dpkg -i packages-microsoft-prod.deb \
+  && rm packages-microsoft-prod.deb \
+  && apt-get update \
+  && ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
+       msodbcsql18 \
+       mssql-tools18 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+USER 1997

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 [![Docker Version](https://img.shields.io/docker/v/idscan/zabbix-proxy-sqlite3)](https://hub.docker.com/r/idscan/zabbix-server-mysql)
 [![Docker Image Size](https://img.shields.io/docker/image-size/idscan/zabbix-server-mysql)](https://hub.docker.com/r/idscan/zabbix-server-mysql)
 
-Zabbix server uses MySQL database with Microsoft ODBC driver for SQL Server on Alpine docker images
+Zabbix server uses MySQL database with Microsoft ODBC driver for SQL Server on Alpine and Ubuntu docker images
 
 ## Uses
 
   * Official docker image Zabbix server (MySQL) LTS
   * Microsoft ODBC driver for SQL Server 18
+  * Alpine-based: `Dockerfile`
+  * Ubuntu-based: `Dockerfile.ubuntu`
 
 ## Test
 


### PR DESCRIPTION
Adds `Dockerfile.ubuntu` as an alternative to the existing Alpine-based `Dockerfile` and updates README accordingly.

### Changes
- `Dockerfile.ubuntu` — new Ubuntu 26.04 (Resolute Raccoon) based image with `msodbcsql18` and `mssql-tools18`
- `README.md` — updated description to mention both Alpine and Ubuntu variants

### Notes
- Microsoft does not officially list Ubuntu 26.04 as supported for ODBC driver, but `packages-microsoft-prod.deb` for 26.04 exists and the noble (24.04) repo packages install and run correctly
- `mssql-tools18` binary path: `/opt/mssql-tools18/bin/sqlcmd`